### PR TITLE
Checkov pre-build binaries aren't compatible with stable Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG TERRAFORM_VERSION="1.10.3" # github-tags/hashicorp/terraform&versioning=semver
 ARG EGET_VERSION="1.3.4" # github-tags/zyedidia/eget&versioning=semver
-ARG CHECKOV_VERSION="3.2.334" # github-tags/bridgecrewio/checkov&versioning=semver
+ARG CHECKOV_VERSION="3.2.346" # github-tags/bridgecrewio/checkov&versioning=semver
 ARG TFDOCS_VERSION="0.19.0" # github-tags/terraform-docs/terraform-docs&versioning=semver
 ARG TFLINT_VERSION="0.54.0" # github-tags/terraform-linters/tflint&versioning=semver
 ARG SOPS_VERSION="3.9.2" # github-tags/getsops/sops&versioning=semver
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.authors="sasa@tekovic.com"
 
 RUN useradd -m terraform -s /bin/bash \
 && apt-get update && apt-get upgrade -V -y \
-&& apt-get install -V -y curl git unzip tar age \
+&& apt-get install -V -y curl git unzip tar age python3-pip \
 && mkdir -p /tmp/terraform \
 && cd /tmp/terraform && curl -o terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip" \
 && unzip terraform.zip && mv terraform /usr/local/bin/ \
@@ -28,10 +28,10 @@ RUN useradd -m terraform -s /bin/bash \
 && tar xvvfz eget.tar.gz --strip-components=1 "eget-${EGET_VERSION}-linux_${TARGETARCH}/eget" \
 && mv eget /usr/local/bin/ \
 && find /usr/local/bin/ -type f -exec chmod 755 {} \; \
-&& eget --to /usr/local/bin/ bridgecrewio/checkov -t ${CHECKOV_VERSION} \
 && eget --to /usr/local/bin/ terraform-docs/terraform-docs -t ${TFDOCS_VERSION} \
 && eget --to /usr/local/bin/ terraform-linters/tflint -t ${TFLINT_VERSION} \
 && eget --to /usr/local/bin/ -a '^sbom.json' getsops/sops -t ${SOPS_VERSION} \
+&& pip3 install checkov==${CHECKOV_VERSION} --break-system-packages \
 && rm -rfv /tmp/* /var/lib/apt/lists/*
 
 USER terraform:terraform


### PR DESCRIPTION
Don't use pre-built Checkov binaries, install Checkov using pip. Drawback is larger container image size.